### PR TITLE
Handle missing Firebase configuration

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -47,8 +47,12 @@ export async function submitIssue(prevState: any, formData: FormData | null) {
   try {
     const { description, category, photo, address, lat, lng } = validatedFields.data;
 
+    if (!admin.apps.length) {
+      throw new Error('Firebase not configured');
+    }
+
     const buffer = Buffer.from(await photo.arrayBuffer());
-    
+
     const bucket = admin.storage().bucket();
     const fileName = `issues/${Date.now()}-${photo.name}`;
     const file = bucket.file(fileName);

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -1,13 +1,24 @@
 
 import admin from 'firebase-admin';
 
-if (!admin.apps.length) {
+// Firebase Admin SDK requires valid credentials which may not always be
+// available in local/test environments. Attempt initialization but swallow any
+// errors so that importing this module does not crash the app.
+try {
+  if (!admin.apps.length) {
     admin.initializeApp({
-        credential: admin.credential.applicationDefault(),
-        databaseURL: `https://${process.env.GCLOUD_PROJECT}.firebaseio.com`,
-        storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+      credential: admin.credential.applicationDefault(),
+      databaseURL: process.env.GCLOUD_PROJECT
+        ? `https://${process.env.GCLOUD_PROJECT}.firebaseio.com`
+        : undefined,
+      storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
     });
+  }
+} catch (error) {
+  console.error('Failed to initialize Firebase Admin SDK:', error);
 }
 
-export const adminDb = admin.firestore();
+// If initialization failed, admin.apps will be empty and firestore() will
+// throw. Guard against this and export `null` instead.
+export const adminDb = admin.apps.length ? admin.firestore() : null;
 export { admin };


### PR DESCRIPTION
## Summary
- catch Firebase admin initialization errors and expose nullable `adminDb`
- guard data layer and server action when Firestore isn't available

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: prompt to configure ESLint)
- `npm run typecheck` (fails: Cannot find module 'react-hook-form', missing cookie property types)


------
https://chatgpt.com/codex/tasks/task_e_68bc8af4dd308320ad6c0db00f800eac