### PR TITLE
Fix issue photo upload binary handling

### DIFF
--- a/src/lib/issue-actions.ts
+++ b/src/lib/issue-actions.ts
@@ -42,11 +42,12 @@ export async function submitIssue(prevState: IssueFormState, formData: FormData)
     let photoUrl: string | null = null;
 
     if (photo && photo.size > 0) {
-      const photoBuffer = Buffer.from(await photo.arrayBuffer());
+      const photoArrayBuffer = await photo.arrayBuffer();
+      const photoBytes = new Uint8Array(photoArrayBuffer);
       const photoId = uuidv4();
       const file = bucket.file(`issues/${photoId}-${photo.name}`);
 
-      await file.save(photoBuffer, {
+      await file.save(photoBytes, {
         contentType: photo.type,
       });
 


### PR DESCRIPTION
## Summary
- replace Node-specific Buffer usage with a Uint8Array when saving uploaded photos
- keep Cloud Storage upload and Firestore writes functioning under non-Node runtimes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de339e73b48320b91dd91945162e58