### PR TITLE
Support configurable Firebase storage bucket

### DIFF
--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -5,12 +5,12 @@ import { getStorage, type FirebaseStorage } from "firebase/storage";
 
 // Your web app's Firebase configuration, with explicit values.
 const firebaseConfig = {
-  "projectId": "civiclens-bexm4",
-  "appId": "1:873086332859:web:8856f2a6ffa3f493ff5e9e",
-  "storageBucket": "civiclens-bexm4.appspot.com",
-  "apiKey": "AIzaSyAanUGeE4WzPNUCfx9d_KSM4vt5cZdStJg",
-  "authDomain": "civiclens-bexm4.firebaseapp.com",
-  "messagingSenderId": "873086332859"
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? "civiclens-bexm4",
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? "1:873086332859:web:8856f2a6ffa3f493ff5e9e",
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "civiclens-bexm4.appspot.com",
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "AIzaSyAanUGeE4WzPNUCfx9d_KSM4vt5cZdStJg",
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "civiclens-bexm4.firebaseapp.com",
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? "873086332859",
 };
 
 // This function can be called from anywhere (client-side) to get the app instance.

--- a/src/lib/server/firebase-admin.ts
+++ b/src/lib/server/firebase-admin.ts
@@ -37,9 +37,15 @@ export function getFirebaseAdmin(): FirebaseAdmin {
     } else {
       app = getApp();
     }
-  
+
+    const storageBucket = process.env.FIREBASE_STORAGE_BUCKET ?? firebaseConfig.storageBucket;
+
+    if (!storageBucket) {
+      throw new Error('Firebase storage bucket is not configured. Set FIREBASE_STORAGE_BUCKET or NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET.');
+    }
+
     const db: Firestore = getFirestore(app);
-    const bucket = getStorage(app).bucket();
+    const bucket = getStorage(app).bucket(storageBucket);
   
     admin = { app, db, bucket };
     return admin;


### PR DESCRIPTION
## Summary
- allow the Firebase web client configuration to pull bucket and related values from environment variables while retaining defaults
- ensure the Firebase Admin SDK selects an explicitly configured storage bucket and fails fast when none is provided

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de3f890fb08320a625a92748bf37b0