### PR TITLE
Fix Firebase Admin storage bucket resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ For Firebase Admin access, provide either of the following:
 
 Regardless of which option you choose, ensure `FIREBASE_PRIVATE_KEY` (directly or within the JSON) is populated with your actual private key value, not a placeholder.
 
+For file uploads you must also configure a Firebase Storage bucket. Set `FIREBASE_STORAGE_BUCKET` (preferred for server-side configuration) or `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` (shared client/server) to the bucket name. If neither variable is provided, the app will fall back to `${projectId}.appspot.com` when your Firebase project has the default storage bucket enabled.
+
 ### Running the Application
 
 Once your environment is configured, you can run the application locally:

--- a/src/lib/server/firebase-admin.ts
+++ b/src/lib/server/firebase-admin.ts
@@ -20,6 +20,11 @@ export function getFirebaseAdmin(): FirebaseAdmin {
   try {
     const serviceAccount = buildServiceAccountFromEnv();
 
+    const storageBucket =
+      process.env.FIREBASE_STORAGE_BUCKET ??
+      process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ??
+      (serviceAccount.projectId ? `${serviceAccount.projectId}.appspot.com` : undefined);
+
     if (!serviceAccount.clientEmail) {
       throw new Error('Firebase Admin client email is not configured.');
     }
@@ -28,20 +33,20 @@ export function getFirebaseAdmin(): FirebaseAdmin {
       throw new Error('FIREBASE_PRIVATE_KEY is not set or is a placeholder in the environment variables.');
     }
 
+    if (!storageBucket) {
+      throw new Error(
+        'Firebase storage bucket is not configured. Set FIREBASE_STORAGE_BUCKET, NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET, or ensure your Firebase project has a default bucket.'
+      );
+    }
+
     let app: App;
     if (!getApps().length) {
       app = initializeApp({
         credential: cert(serviceAccount),
-        storageBucket: firebaseConfig.storageBucket,
+        storageBucket,
       });
     } else {
       app = getApp();
-    }
-
-    const storageBucket = process.env.FIREBASE_STORAGE_BUCKET ?? firebaseConfig.storageBucket;
-
-    if (!storageBucket) {
-      throw new Error('Firebase storage bucket is not configured. Set FIREBASE_STORAGE_BUCKET or NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET.');
     }
 
     const db: Firestore = getFirestore(app);


### PR DESCRIPTION
## Summary
- derive the Firebase Admin storage bucket from explicit environment variables with a fallback to the service account project ID
- use the resolved bucket when initializing the Admin app and storage client to keep them in sync
- document the new storage bucket fallback behaviour and configuration expectations in the README

## Testing
- npm run lint
- manual issue submission test with image (fails: Firebase storage bucket civiclens-bexm4.appspot.com is not provisioned)

------
https://chatgpt.com/codex/tasks/task_e_68de53fbb7688320b682510dabfe3639