### PR TITLE
Fix login page form state hook compatibility

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 
 'use client';
-import { useActionState, useEffect } from 'react';
-import { useFormStatus } from 'react-dom';
+import { useEffect } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -22,7 +22,7 @@ function LoginButton() {
 
 export default function LoginPage() {
     const { toast } = useToast();
-    const [state, formAction] = useActionState(login, undefined);
+    const [state, formAction] = useFormState(login, undefined);
 
     useEffect(() => {
         if (state?.success === false && state.message) {


### PR DESCRIPTION
## Summary
- replace the deprecated `useActionState` hook usage with `useFormState` on the login page to match the available React APIs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de5734c0fc8320afb2da36ac619d68