### PR TITLE
Align Firebase storage bucket defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For Firebase Admin access, provide either of the following:
 
 Regardless of which option you choose, ensure `FIREBASE_PRIVATE_KEY` (directly or within the JSON) is populated with your actual private key value, not a placeholder.
 
-For file uploads you must also configure a Firebase Storage bucket. Set `FIREBASE_STORAGE_BUCKET` (preferred for server-side configuration) or `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` (shared client/server) to the bucket name. If neither variable is provided, the app will fall back to `${projectId}.appspot.com` when your Firebase project has the default storage bucket enabled.
+For file uploads you must also configure a Firebase Storage bucket. Set `FIREBASE_STORAGE_BUCKET` (preferred for server-side configuration) or `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` (shared client/server) to the bucket name. If neither variable is provided, the app will fall back to the bucket defined in `src/lib/firebase-client.ts` (default `civiclens-bexm4.firebasestorage.app`) or, if unavailable, to `${projectId}.appspot.com` when your Firebase project uses the legacy default storage bucket.
 
 ### Running the Application
 

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -7,7 +7,7 @@ import { getStorage, type FirebaseStorage } from "firebase/storage";
 const firebaseConfig = {
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? "civiclens-bexm4",
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? "1:873086332859:web:8856f2a6ffa3f493ff5e9e",
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "civiclens-bexm4.appspot.com",
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "civiclens-bexm4.firebasestorage.app",
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "AIzaSyAanUGeE4WzPNUCfx9d_KSM4vt5cZdStJg",
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "civiclens-bexm4.firebaseapp.com",
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? "873086332859",

--- a/src/lib/server/firebase-admin.ts
+++ b/src/lib/server/firebase-admin.ts
@@ -23,6 +23,7 @@ export function getFirebaseAdmin(): FirebaseAdmin {
     const storageBucket =
       process.env.FIREBASE_STORAGE_BUCKET ??
       process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ??
+      firebaseConfig.storageBucket ??
       (serviceAccount.projectId ? `${serviceAccount.projectId}.appspot.com` : undefined);
 
     if (!serviceAccount.clientEmail) {


### PR DESCRIPTION
## Summary
- align the Firebase client default storage bucket with the deployed project bucket
- allow the Firebase Admin helper to fall back to the client storage bucket when env vars are absent
- document the updated storage bucket fallback behavior in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de5ae8a4d48320af2d0aae3bd4abbb