### PR TITLE
Fix Firebase storage bucket normalization

### DIFF
--- a/src/lib/server/firebase-admin.ts
+++ b/src/lib/server/firebase-admin.ts
@@ -105,11 +105,10 @@ function normalizeStorageBucket(bucket: string | undefined): string | undefined 
     normalizedBucket = normalizedBucket.slice('gs://'.length);
   }
 
-  // When using Firebase client configuration values the storage bucket often
-  // ends with `firebasestorage.app`, but the Admin SDK expects the underlying
-  // Google Cloud Storage bucket name which ends in `appspot.com`.
-  if (normalizedBucket.endsWith('.firebasestorage.app')) {
-    normalizedBucket = normalizedBucket.replace(/\.firebasestorage\.app$/, '.appspot.com');
+  // Strip any accidental path suffixes so we only keep the bucket identifier.
+  const slashIndex = normalizedBucket.indexOf('/');
+  if (slashIndex !== -1) {
+    normalizedBucket = normalizedBucket.slice(0, slashIndex);
   }
 
   return normalizedBucket;


### PR DESCRIPTION
## Summary
- update the Firebase Admin storage bucket normalization to keep the provided bucket domain intact
- strip only the `gs://` prefix and any accidental path suffixes when configuring the bucket

## Testing
- npm run lint *(fails: Failed to load config "next/typescript" to extend from.)*


------
https://chatgpt.com/codex/tasks/task_e_68de61b770f48320a84987ef47091e55