### PR TITLE
Fix default Firebase Storage bucket configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For Firebase Admin access, provide either of the following:
 
 Regardless of which option you choose, ensure `FIREBASE_PRIVATE_KEY` (directly or within the JSON) is populated with your actual private key value, not a placeholder.
 
-For file uploads you must also configure a Firebase Storage bucket. Set `FIREBASE_STORAGE_BUCKET` (preferred for server-side configuration) or `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` (shared client/server) to the bucket name. If neither variable is provided, the app will fall back to the bucket defined in `src/lib/firebase-client.ts` (default `civiclens-bexm4.firebasestorage.app`) or, if unavailable, to `${projectId}.appspot.com` when your Firebase project uses the legacy default storage bucket.
+For file uploads you must also configure a Firebase Storage bucket. Set `FIREBASE_STORAGE_BUCKET` (preferred for server-side configuration) or `NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET` (shared client/server) to the bucket name. If neither variable is provided, the app will fall back to the bucket defined in `src/lib/firebase-client.ts` (default `civiclens-bexm4.appspot.com`) or, if unavailable, to `${projectId}.appspot.com` when your Firebase project uses the legacy default storage bucket.
 
 ### Running the Application
 

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -7,7 +7,7 @@ import { getStorage, type FirebaseStorage } from "firebase/storage";
 const firebaseConfig = {
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ?? "civiclens-bexm4",
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? "1:873086332859:web:8856f2a6ffa3f493ff5e9e",
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "civiclens-bexm4.firebasestorage.app",
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ?? "civiclens-bexm4.appspot.com",
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "AIzaSyAanUGeE4WzPNUCfx9d_KSM4vt5cZdStJg",
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ?? "civiclens-bexm4.firebaseapp.com",
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ?? "873086332859",


### PR DESCRIPTION
## Summary
- update the default Firebase Storage bucket to use the correct appspot.com domain
- refresh documentation to reference the corrected default bucket value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de644eb3b88320949647c6809c70a5